### PR TITLE
Homepage hero and navigation title refinements

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -9,10 +9,6 @@ const accentLight = "rgba(255, 255, 255, 0.3)";
 const accentGradient = "rgb(255, 255, 255)";
 ---
 
-<script type="module">
-  ScrollReveal().reveal(".link-card", { delay: 300 });
-</script>
-
 <ul class="card-container">
   {
     promotion.map((promotion) => (
@@ -79,13 +75,13 @@ const accentGradient = "rgb(255, 255, 255)";
     min-width: 25rem;
     height: auto;
     padding: 1rem;
-    background-color: #23262d;
+    background-color: transparent;
     background-image: none;
     background-size: 150%;
-    border-radius: 27px;
+    border-radius: 0px;
     background-position: 100%;
     transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+    box-shadow: none;
   }
 
   @media screen and (max-width: 500px) {
@@ -114,10 +110,10 @@ const accentGradient = "rgb(255, 255, 255)";
     text-decoration: none;
     line-height: 1.4;
     padding: calc(1.5rem - 1px);
-    border-radius: 8px;
+    border-radius: 6px;
     color: white;
-    background-color: #23262d;
-    opacity: 0.8;
+    background-color: transparent;
+    opacity: 1;
   }
   h2 {
     margin: 0;

--- a/src/components/HeadingMenu.astro
+++ b/src/components/HeadingMenu.astro
@@ -3,6 +3,11 @@ import Image from "astro/components/Image.astro";
 import headerLogo from "../images/header-logo.svg";
 import Logo from "../components/Logo.astro";
 const accentColor = "#f05a24";
+interface Props {
+  navTitle?: string;
+}
+
+const { navTitle } = Astro.props;
 ---
 
 <header>
@@ -63,6 +68,11 @@ const accentColor = "#f05a24";
         </button>
       </div>
       <Logo class="header-logo" />
+      {
+        navTitle && (
+          <li class="site-title" aria-label="Business title">{navTitle}</li>
+        )
+      }
       <li><a class="header-menu-item" href="/" data-astro-prefetch>Home</a></li>
       <li>
         <a class="header-menu-item" href="/gallery/" data-astro-prefetch
@@ -107,10 +117,10 @@ const accentColor = "#f05a24";
     text-decoration: none;
     flex-direction: row;
     align-items: center;
-    justify-content: space-evenly;
-    gap: 2rem;
+    justify-content: flex-start;
+    gap: 1.5rem;
     height: 6rem;
-    padding-right: 2rem;
+    padding: 0 2rem;
     margin-top: -0.5rem;
     width: 100%;
     background-color: #ffffff;
@@ -121,9 +131,20 @@ const accentColor = "#f05a24";
 
   .header-logo {
     justify-self: flex-start;
-    margin-left: -10rem;
+    margin-left: 0;
     height: 4rem;
     fill: #f06124;
+  }
+
+  .site-title {
+    color: black;
+    font-family: "Bodoni Moda", "Cormorant Garamond", serif;
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    margin-right: auto;
+    white-space: nowrap;
   }
 
   .header-menu-item {
@@ -150,6 +171,15 @@ const accentColor = "#f05a24";
     .header-logo {
       display: none;
     }
+
+    .site-title {
+      color: white;
+      font-size: 1.6rem;
+      margin-right: 0;
+      white-space: normal;
+      text-align: center;
+    }
+
     .heading-menu {
       flex-direction: column;
       height: 100vh;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,8 +2,9 @@
 interface Props {
   title?: string;
   description?: string;
+  navTitle?: string;
 }
-const { title } = Astro.props;
+const { title, navTitle } = Astro.props;
 import MainHead from "./MainHead.astro";
 import HeadingMenu from "../components/HeadingMenu.astro";
 import Footer from "../components/Footer.astro";
@@ -42,7 +43,7 @@ const accentColour = "#f2f2f2";
           style="display:none;visibility:hidden"></iframe></noscript
       >
       <!-- End Google Tag Manager (noscript) -->
-      <HeadingMenu transition:persist />
+      <HeadingMenu navTitle={navTitle} transition:persist />
       <div class="content">
         <slot />
       </div>

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -46,7 +46,25 @@ export async function getAllPromotions() {
   const homeQuery = '*[_type == "promotion"]';
   const homeParams = {};
   const homeImages = await useSanityClient().fetch(homeQuery, homeParams);
-  return homeImages
+
+  // Keep homepage cards in a fixed business-defined order.
+  const cardOrder = ["kitchens", "wardrobes", "built-ins"];
+  const getRank = (title = "") => {
+    const normalized = title.toLowerCase().trim();
+    const matchIndex = cardOrder.findIndex((item) => normalized.includes(item));
+    return matchIndex === -1 ? Number.MAX_SAFE_INTEGER : matchIndex;
+  };
+
+  return [...homeImages].sort((a, b) => {
+    const rankA = getRank(a?.title);
+    const rankB = getRank(b?.title);
+
+    if (rankA !== rankB) {
+      return rankA - rankB;
+    }
+
+    return (a?.title || "").localeCompare(b?.title || "");
+  });
 }
 
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,23 @@ const posts = await getAllPosts();
 const promotion = await getAllPromotions();
 const headerImg = "../images/homepage1.jpg";
 console.log("this is a server test", homeText[0]);
+
+const getBlockText = (blocks = []) => {
+  return blocks
+    .filter((block) => block?._type === "block" && Array.isArray(block.children))
+    .map((block) =>
+      block.children
+        .map((child) => child?.text || "")
+        .join("")
+        .trim()
+    )
+    .filter(Boolean)
+    .join(" ");
+};
+
+const homePage = homeText?.[0] || {};
+const subheadingText = getBlockText(homePage.subheading);
+const bodyText = getBlockText(homePage.body);
 ---
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -24,13 +41,15 @@ console.log("this is a server test", homeText[0]);
   href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap"
   rel="stylesheet"
 />
+<link
+  href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,700;6..96,800&display=swap"
+  rel="stylesheet"
+/>
 
 <script type="module">
   ScrollReveal().version;
   ScrollReveal({ distance: "60px" });
   ScrollReveal().reveal(".subtitle-header", { delay: 200 });
-  ScrollReveal().reveal(".lower-sub-header", { delay: 400, duration: 300 });
-  ScrollReveal().reveal(".cta-container", { delay: 400 });
 </script>
 
 <reference types="astro/client"></reference>
@@ -41,15 +60,14 @@ console.log("this is a server test", homeText[0]);
   <title>{homeText[0].subtitle ?? null}{console.log(homeText)}</title>
 </html>
 
-<Layout>
+<Layout navTitle={homePage.subtitle}>
   <main>
     <header class="header-container">
       <HeaderSlider />
 
       <div class="subtitle_container">
-        <h1 class="title-header">{homeText[0].subtitle ?? null}{console.log(homeText)}</h1>
         <h5 class="subtitle-header">
-          {homeText[0].subheading[0].children[0].text ?? null}
+          {subheadingText}
         </h5>
 
         <a href="/contact/" class="call-to-action" data-astro-prefetch
@@ -73,7 +91,7 @@ console.log("this is a server test", homeText[0]);
 
     <div class="cta-container">
       <h6 class="lower-sub-header body-text">
-        {homeText[0].subheading[0].children[0].text ?? null}
+        {bodyText}
       </h6>
       <!-- <h2 class="info-cta">{homeText[0].pageBuilder[0]?.subheaders ?? null}</h2> -->
       <a class="subheader--contact__button" href="/contact/"> Contact </a>
@@ -101,11 +119,6 @@ console.log("this is a server test", homeText[0]);
     margin-bottom: 0.2rem;
   }
 
-  .title-header {
-    margin-top: 0;
-    font-size: 2.5rem;
-  }
-
   .header-container {
     position: relative;
   }
@@ -123,29 +136,26 @@ console.log("this is a server test", homeText[0]);
     right: 0;
     top: 20%;
     margin: 0 auto;
-    padding: 2.5rem;
-    width: 70%;
-    max-width: 40rem;
-    min-height: 22rem;
+    padding: 1rem;
+    width: 48%;
+    max-width: 28rem;
+    min-height: 10rem;
     display: flex;
     justify-content: center;
     flex-flow: column;
     align-items: center;
     background-color: rgb(0, 0, 0, 0.5);
-    border-radius: 0px;
+    border-radius: 0;
   }
 
   @media only screen and (min-width: 300px) and (max-width: 550px) {
     .subtitle_container {
       top: 2rem;
       min-height: 2rem;
-      padding: 1.5rem;
+      padding: 0.8rem;
+      width: 78%;
     }
 
-    .title-header {
-      font-size: 2.8rem;
-      margin-bottom: -0.5rem;
-    }
     .subtitle-header {
       font-size: 16px !important;
     }
@@ -154,11 +164,6 @@ console.log("this is a server test", homeText[0]);
   @media screen and (min-width: 700px) {
     .subtitle_container {
       top: 15rem;
-    }
-
-    .title-header {
-      font-size: 3.8rem;
-      margin-bottom: -0.5rem;
     }
   }
 


### PR DESCRIPTION
## Summary
- move homepage business title into the top navigation bar
- render bottom homepage text from the body field instead of duplicating subheading
- remove scroll pop-up from homepage cards and bottom CTA area
- reduce card corner rounding and remove gray card box backgrounds
- enforce homepage promotion card order: kitchens, wardrobes, built-ins
- tune hero subtitle overlay box sizing and typography

## Files changed
- src/pages/index.astro
- src/components/HeadingMenu.astro
- src/layouts/Layout.astro
- src/components/Card.astro
- src/lib/api.js